### PR TITLE
Use deprecated API version

### DIFF
--- a/overlays/dev-1-aws-us-east-1/kustomization.yaml
+++ b/overlays/dev-1-aws-us-east-1/kustomization.yaml
@@ -40,3 +40,11 @@ images:
     newTag: 6.2.1
 
 buildMetadata: [originAnnotations]
+
+patchesJson6902:
+  - target:
+      group: "autoscaling"
+      version: v2beta2
+      kind: HorizontalPodAutoscaler
+      name: podinfo
+    path: patch-hpa-version.yaml

--- a/overlays/dev-1-aws-us-east-1/patch-hpa-version.yaml
+++ b/overlays/dev-1-aws-us-east-1/patch-hpa-version.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: "/apiVersion"
+  value: autoscaling/v2beta1


### PR DESCRIPTION
Uses deprecated HPA version `autoscaling/v2beta2` to be removed in kubernetes `1.25`.

See summary: https://github.com/waaghals/gitops/actions/runs/3288983616/attempts/1#summary-9005105994