### PR TITLE
Use removed API version example

### DIFF
--- a/overlays/dev-1-aws-us-east-1/kustomization.yaml
+++ b/overlays/dev-1-aws-us-east-1/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - ../../base/podinfo
+  - removed-api.yaml
 
 configMapGenerator:
   - name: environment

--- a/overlays/dev-1-aws-us-east-1/removed-api.yaml
+++ b/overlays/dev-1-aws-us-east-1/removed-api.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: nginx1-deployment
+  labels:
+    app: nginx1-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx1
+  template:
+    metadata:
+      labels:
+        app: nginx1
+    spec:
+      containers:
+      - name: nginx
+        image: registry.k8s.io/nginx:1.7.9
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
Downgrade deployment to removed api version `apps/v1beta2`. Removed from kubernetes `1.16`

See summary: https://github.com/waaghals/gitops/actions/runs/3288922090/attempts/1#summary-9004930842